### PR TITLE
feat: auth provider + hook Google GSI client

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_GOOGLE_CLIENT_ID="xxx.apps.googleusercontent.com"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@types/react-dom": "^18.0.3",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "react-facebook-login": "^4.1.1",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.6.4",

--- a/src/components/AuthProvider.tsx
+++ b/src/components/AuthProvider.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+
+export const AuthContext = React.createContext<any>({})
+
+export default function AuthProvider({ children }: any) {
+	const [userToken, setUserToken] = React.useState()
+
+	React.useEffect(() => {
+		if (!userToken) return
+		console.info("userToken à été modifié")
+	}, [userToken])
+
+	return (
+		<AuthContext.Provider
+			value={{
+				userToken,
+				setUserToken,
+			}}
+		>
+			{children}
+		</AuthContext.Provider>
+	)
+}

--- a/src/components/Joel/Facebook.js
+++ b/src/components/Joel/Facebook.js
@@ -1,0 +1,49 @@
+import React, { Component } from "react";
+import FacebookLoginBtn from "react-facebook-login";
+
+export default class LoginFacebook extends Component {
+    state = {
+        auth: false,
+        name: '',
+        picture: ''
+    }
+
+    componentClicked = ()=>{
+        console.log('Facebook btn clicked');
+    }
+
+    responseFacebook = (response) => {
+        console.log(response);
+        this.setState({
+            auth: true,
+            name: response.name,
+            picture: response.picture.data.url,
+        })
+    }
+
+    render(){
+        let facebookData;
+
+        this.state.auth ?
+            facebookData = (
+                <div>
+                    <img src={this.state.picture} alt={this.state.name} />
+		            <h3>Welcome {this.state.name}</h3>
+                </div>
+            ):
+            facebookData = (
+            <FacebookLoginBtn 
+                appId=""
+                autoLoad={true}
+                fields="name,picture"
+                onClick={this.componentClicked}
+                callback={this.responseFacebook} />
+            );
+        
+        return(
+            <>
+                {facebookData}
+            </>
+        );
+    }
+}

--- a/src/components/Joel/HelloName.tsx
+++ b/src/components/Joel/HelloName.tsx
@@ -1,11 +1,15 @@
 import React from "react"
+import Facebook from '../Joel/Facebook'
 
 type IngridProps = {
 	name: string
 }
 
 const HelloName = ({ name }: IngridProps) => {
-	return <>Hello {name}</>
+	return <>
+			Hello {name}
+			<div><Facebook /></div>
+		   </>
 }
 
 export default HelloName

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,13 +7,16 @@ import reportWebVitals from "./reportWebVitals"
 
 // Providers
 import { BrowserRouter as Router } from "react-router-dom" // Gestion des routes
+import AuthProvider from "./components/AuthProvider"
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement)
 root.render(
 	<React.StrictMode>
-		<Router>
-			<App />
-		</Router>
+		<AuthProvider>
+			<Router>
+				<App />
+			</Router>
+		</AuthProvider>
 	</React.StrictMode>
 )
 

--- a/src/pages/Thomas.tsx
+++ b/src/pages/Thomas.tsx
@@ -1,20 +1,34 @@
 import React from "react"
-import HelloName from "../components/Thomas/HelloName"
+import { AuthContext } from "../components/AuthProvider"
+import { useConnect } from "../utils/useGoogleGsiClient"
+import H1 from "../components/basics/H1"
+import Paragraph from "../components/basics/Paragraph"
 
 const Thomas = () => {
-	return <HelloName name="Thomas" />
+	// On appel le context "AuthContext" pour y stocker le userToken
+	const { userToken, setUserToken } = React.useContext(AuthContext)
+
+	// On fait une demande de connexion One Tap à google
+	// Todo: Ajouter la gestion de session
+	const user = useConnect(process.env.REACT_APP_GOOGLE_CLIENT_ID, true, false)
+
+	// On stock le userToken dans le contexte (pour utilisation ailleur dans le projet)
+	React.useEffect(() => {
+		if (userToken) return
+		setUserToken(user)
+	}, [setUserToken, user, userToken])
+
+	return (
+		<>
+			<H1>GSI Client Google</H1>
+			<br />
+			<Paragraph>Connexion à l'aide de la nouvelle API de Google</Paragraph>
+			<br />
+			<Paragraph>userToken: {userToken ?? "non connecté"}</Paragraph>
+			<br />
+			{userToken ? <Paragraph>Connexion OK (Todo: déconnexion)</Paragraph> : <div id="buttonDiv"></div>}
+		</>
+	)
 }
 
 export default Thomas
-
-// Exemple avec des props définis
-type UnComposantProps = {
-	unTexte: string
-	unTexteOptionnel?: string
-	unNombre: number
-	unTableau: []
-	unObjet: {}
-	unTableauDeNombres: number[]
-	nimporteQuoi: any
-}
-export const UnComposant = ({ unTexte }: UnComposantProps) => <>{unTexte}</>

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -1,1 +1,87 @@
 /// <reference types="react-scripts" />
+
+// https://accounts.google.com/gsi/client
+
+interface IdConfiguration {
+	client_id: string | undefined
+	auto_select?: boolean
+	callback: (handleCredentialResponse: CredentialResponse) => void
+	login_uri?: string
+	native_callback?: Function
+	cancel_on_tap_outside?: boolean
+	prompt_parent_id?: string
+	nonce?: string
+	context?: string
+	state_cookie_domain?: string
+	ux_mode?: "popup" | "redirect"
+	allowed_parent_origin?: string | string[]
+	intermediate_iframe_close_callback?: Function
+}
+
+interface CredentialResponse {
+	credential?: string
+	select_by?:
+		| "auto"
+		| "user"
+		| "user_1tap"
+		| "user_2tap"
+		| "btn"
+		| "btn_confirm"
+		| "brn_add_session"
+		| "btn_confirm_add_session"
+	clientId?: string
+}
+
+interface GsiButtonConfiguration {
+	type: "standard" | "icon"
+	theme?: "outline" | "filled_blue" | "filled_black"
+	size?: "large" | "medium" | "small"
+	text?: "signin_with" | "signup_with" | "continue_with" | "signup_with"
+	shape?: "rectangular" | "pill" | "circle" | "square"
+	logo_alignment?: "left" | "center"
+	width?: string
+	local?: string
+}
+
+interface PromptMomentNotification {
+	isDisplayMoment: () => boolean
+	isDisplayed: () => boolean
+	isNotDisplayed: () => boolean
+	getNotDisplayedReason: () =>
+		| "browser_not_supported"
+		| "invalid_client"
+		| "missing_client_id"
+		| "opt_out_or_no_session"
+		| "secure_http_required"
+		| "suppressed_by_user"
+		| "unregistered_origin"
+		| "unknown_reason"
+	isSkippedMoment: () => boolean
+	getSkippedReason: () => "auto_cancel" | "user_cancel" | "tap_outside" | "issuing_failed"
+	isDismissedMoment: () => boolean
+	getDismissedReason: () => "credential_returned" | "cancel_called" | "flow_restarted"
+	getMomentType: () => "display" | "skipped" | "dismissed"
+}
+interface Window {
+	google?: {
+		accounts: {
+			id: {
+				initialize: (input: IdConfiguration) => void
+				prompt: (momentListener?: (res: PromptMomentNotification) => void) => void
+				renderButton: (parent: HTMLElement | null, options: GsiButtonConfiguration, clickHandler?: Function) => void
+				disableAutoSelect: Function
+				storeCredential: Function<{
+					credentials: { id: string; password: string }
+					callback: Function
+				}>
+				cancel: () => void
+				onGoogleLibraryLoad: Function
+				revoke: Function<{
+					hint: string
+					callback: Function<{ successful: boolean; error: string }>
+				}>
+			}
+			oauth2: any
+		}
+	}
+}

--- a/src/utils/useGoogleGsiClient.tsx
+++ b/src/utils/useGoogleGsiClient.tsx
@@ -137,7 +137,7 @@ export default function useGoogleGsiClient(
 			// On remplace la DIV par le bouton de connexion
 			if (params.button) {
 				window.google.accounts.id.renderButton(document.getElementById(params.button_divId), {
-					type: "icon",
+					type: "standard",
 					theme: "outline",
 					size: "large",
 					width: "300",
@@ -191,7 +191,7 @@ export default function useGoogleGsiClient(
  * @return user Informations de connexion
  */
 export const useConnect = (
-	client_id: string | null,
+	client_id: string | null | undefined,
 	button: boolean = true,
 	oneTap: boolean = false,
 	newParams = {}
@@ -237,3 +237,5 @@ export const useScopeAccess = (
 
 	return { accessToken: sessionStorage.getItem("accessToken") ?? accessToken }
 }
+
+// Todo: Déconnexion

--- a/src/utils/useGoogleGsiClient.tsx
+++ b/src/utils/useGoogleGsiClient.tsx
@@ -1,0 +1,239 @@
+import React from "react"
+
+/**
+ * Utilisation du client GSI fourni par Google API
+ * @author Thomas Savournin <tosave.vbl@gmail.com>
+ * @example const { user, setParams, setInit } = useGoogleGsiClient(client_id, true)
+ * @example setParams({ ...params, oauth2: true, oauth2_scope: "https://www.googleapis.com/auth/calendar" })
+ * @example setInit(true)
+ * @param client_id ID du client Google API (peut également être défini avec setParams)
+ * @param button Utilisation de la connexion par Bouton (peut également être défini avec setParams)
+ * @param oneTap Utilisation de la connexion rapide "One Tap" (peut également être défini avec setParams)
+ * @param oauth2 Utilisation de la connexion avancée Oauth2 (peut également être défini avec setParams)
+ * @return user Informations en retour à la connexion Bouton ou One Tap
+ * @return jwtToken Token JWT en réponse à l'authentification Oauth2
+ * @return gsiScriptLoaded Le script à bien été chargé dans le DOM
+ * @return params Paramètres actuels
+ * @return setParams Configuration des paramètres avant initialisation
+ * @return Init État d'initialisation du script
+ * @return setInit Mettre sur true pour initier le script après avoir configuré les paramètres
+ */
+
+export default function useGoogleGsiClient(
+	client_id: string | null = null,
+	button: boolean | null = null,
+	oneTap: boolean | null = null,
+	oauth2: boolean | null = null
+): {
+	user: any
+	jwtToken: any
+	accessToken: any
+	gsiScriptLoaded: boolean | undefined
+	params: any
+	setParams: React.Dispatch<any>
+	init: boolean
+	setInit: React.Dispatch<React.SetStateAction<boolean>>
+} {
+	// Paramètres par défaut
+	const [params, setParams] = React.useState<any>({
+		client_id: client_id ?? "",
+		script_id: "google-client-script",
+		script_async: true,
+		script_parent: "body",
+		script_url: "https://accounts.google.com/gsi/client",
+		initialize_auto_select: true,
+		initialize_cancel_on_tap_outside: false,
+		initialize_nonce: Math.random().toString(),
+		button: button ?? false,
+		button_divId: "buttonDiv",
+		button_custom: {},
+		oneTap: oneTap ?? false,
+		oauth2: oauth2 ?? false,
+		oauth2_scope: null,
+		oauth2_prompt: "consent", // "", "none", "consent", "select_account"
+		access: false,
+	})
+
+	const [init, setInit] = React.useState<boolean>(false)
+
+	const [user, setUser] = React.useState<any>()
+	const [jwtToken, setJwtToken] = React.useState<any>()
+	const [accessToken, setAccessToken] = React.useState<any>()
+
+	const [gsiScriptLoaded, setGsiScriptLoaded] = React.useState<boolean>()
+
+	React.useEffect(() => {
+		if (!init) return
+
+		initGoogleClientScript()
+	})
+
+	// On ajoute un script dans le DOM et on l'active (onload)
+	const initGoogleClientScript = () => {
+		if (user?._id || jwtToken || accessToken || gsiScriptLoaded) return
+
+		const script = document.createElement("script")
+		script.src = params.script_url
+		script.onload = initGsiScript
+		script.async = params.script_async
+		script.id = params.script_id
+		document.querySelector(params.script_parent)?.appendChild(script)
+	}
+
+	const initGsiScript = () => {
+		if (!window.google || gsiScriptLoaded) return
+
+		// Le script GSI est chargé
+		console.info("GSI script loaded")
+		setGsiScriptLoaded(true)
+
+		// Si une authentification oauth2 est demandée
+		// https://developers.google.com/identity/oauth2/web/guides/migration-to-gis#implicit_flow_examples
+		if (params.access) {
+			// On initialise la demande d'AccessToken (pour authentification avec scope)
+			const client = window.google.accounts.oauth2.initTokenClient({
+				client_id: params.client_id,
+				scope: params.oauth2_scope,
+				callback: (tokenResponse: any) => {
+					setAccessToken(tokenResponse.access_token)
+					console.info("AccessToken récupéré")
+				},
+				prompt: params.oauth2_prompt,
+			})
+
+			// On affiche la popup de validation Google
+			console.info("get access Authentification")
+			client.requestAccessToken()
+		}
+
+		if (params.oauth2) {
+			// On initialise la demande de jeton JWT (pour authentification avec scope)
+			const client = window.google.accounts.oauth2.initCodeClient({
+				client_id: params.client_id,
+				scope: params.oauth2_scope,
+				ux_mode: "popup",
+				callback: (response: any) => {
+					setJwtToken(response.code)
+					console.info("Token JWT récupéré")
+				},
+			})
+
+			// On affiche la popup de validation Google
+			console.info("get oauth2 validation")
+			client.requestCode()
+		}
+
+		// Si une connexion rapide est demandée (button ou oneTap)
+		if (params.button || params.oneTap) {
+			// On initialise une connexion rapide
+			window.google.accounts.id.initialize({
+				client_id: params.client_id,
+				callback: handleGoogleSignIn,
+				auto_select: params.initialize_auto_select,
+				cancel_on_tap_outside: params.initialize_cancel_on_tap_outside,
+				nonce: params.initialize_nonce,
+			})
+
+			// On remplace la DIV par le bouton de connexion
+			if (params.button) {
+				window.google.accounts.id.renderButton(document.getElementById(params.button_divId), {
+					type: "icon",
+					theme: "outline",
+					size: "large",
+					width: "300",
+					...params.button_custom,
+				})
+				console.info("Init connexion with button")
+			}
+
+			// On utilise la nouvelle connexion "One Tap"
+			if (params.oneTap) {
+				window.google.accounts.id.prompt((notification) => {
+					if (notification.isNotDisplayed() || notification.isSkippedMoment()) {
+						console.info("Problème de connexion One Tap")
+					} else {
+						console.info("Connexion One Tap réussie")
+					}
+				})
+				console.info("Init One Tap prompt")
+			}
+		}
+	}
+
+	const handleGoogleSignIn = (res: CredentialResponse) => {
+		if (!res.clientId || !res.credential) return
+
+		// On récupère les informations d'utilisateur
+		setUser(res.credential)
+		console.info("User JWT récupéré")
+	}
+
+	return {
+		user: user,
+		jwtToken: jwtToken,
+		accessToken: accessToken,
+		gsiScriptLoaded: gsiScriptLoaded,
+		params: params,
+		setParams: setParams,
+		init: init,
+		setInit: setInit,
+	}
+}
+
+/**
+ * Connexion par API Google GSI
+ * https://developers.google.com/identity/gsi/web
+ * @author Thomas Savournin <tosave.vbl@gmail.com>
+ * @param client_id ID du client Google API, ne s'exécute pas si null
+ * @param button Utilisation du bouton de connexion
+ * @param oneTap Utilisation de la connexion rapide One Tap
+ * @param newParams Autres paramêtres useGoogleGsiClient
+ * @return user Informations de connexion
+ */
+export const useConnect = (
+	client_id: string | null,
+	button: boolean = true,
+	oneTap: boolean = false,
+	newParams = {}
+) => {
+	const { user, setInit, params, setParams } = useGoogleGsiClient(client_id, button, oneTap)
+
+	React.useEffect(() => {
+		setParams({ ...params, ...newParams })
+		setInit(true)
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [])
+
+	return user
+}
+
+/**
+ * Obtention d'un token d'accès avec les droits nécessaires
+ * https://developers.google.com/identity/oauth2/web/guides/use-token-model
+ * @author Thomas Savournin <tosave.vbl@gmail.com>
+ * @example const { accessToken } = useScopeAccess(GOOGLE_CLIENT_ID, "https://www.googleapis.com/auth/calendar")
+ * @param client_id ID du client Google API
+ * @param scope Liste des scopes à utiliser pour la validation
+ * @returns accessToken token d'identification avec les droits scope configurés
+ */
+export const useScopeAccess = (
+	client_id: string,
+	scope: string = "",
+	session: boolean = true,
+	prompt: string = "consent"
+) => {
+	const { accessToken, params, setParams, init, setInit } = useGoogleGsiClient(client_id)
+
+	React.useEffect(() => {
+		if (!client_id || init || accessToken || sessionStorage.getItem("accessToken")) return
+		setParams({ ...params, access: true, oauth2_scope: scope, oauth2_prompt: prompt })
+		setInit(true)
+	}, [accessToken, client_id, init, params, prompt, scope, setInit, setParams])
+
+	React.useEffect(() => {
+		if (!accessToken || !session) return
+		sessionStorage.setItem("accessToken", accessToken)
+	}, [accessToken, session])
+
+	return { accessToken: sessionStorage.getItem("accessToken") ?? accessToken }
+}


### PR DESCRIPTION
Ajout d'un `Hook` personnalisé pour utiliser la nouvelle API GSI Client Google
- `useGoogleGsiClient.tsx` Le hook principal + hooks simplifiés pour l'utilisation
- `react-app-env.d.ts` Définition de types pour GSI Client

Ajout d'un Provider pour stocker les données de connexion et d'utilisateur
- `AuthProvider.tsx` HOC qui contient un `context` réutilisable dans l'application
- `index.tsx` On wrap l'app avec le provider pour que le `context` soit utilisable partout
- `.env.production` Pour stocker le `Client ID` Google, utiliser `.env.local` à la place pour les tests en local

⚠️ le serveur local doit être redémarré pour prendre en compte les modification sur `.env.local`
⚠️ `Client ID` doit être créé dans la [Console Google](https://console.cloud.google.com/apis/credentials) avec les bons `Origines JavaScript` : `http://localhost` et `http://localhost:3000` pour les tests

Exemple d'utilisation de la connexion Google avec un bouton
- `Thomas.tsx` Affichage d'un bouton de connexion et récupération du clientToken

ℹ️ Le 2ème argument de `useConnect` vaut `true` pour l'utilisation d'un bouton
ℹ️ Le 3ème argument affiche le nouveau `One Tap` de Google s'il est configuré sur `true` (connexion rapide)

Le hook sera à améliorer en fonction de nos besoins (gestion des sessions, déconnexion, etc...)

Rien n'oblige à l'utiliser mais les script react d'auth google fonctionnent sur les anciennes API et peuvent poser des problèmes de compatibilité avec les dernières versions de React.